### PR TITLE
Don't assume build username within the docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ services:
       - KAS_BUILD_DIR=$${KAS_WORK_DIR}/build
     volumes:
       - ./:/mnt/yocto-kas
-      - ~/.ssh:/builder/.ssh
+      - ~/.ssh:/etc/skel/.ssh


### PR DESCRIPTION
Previously we assumed the build user is named "builder" within the KAS
container. However, this could be open to change. As the user is added
at runtime, we can mount the SSH folder to /etc/skel/.ssh instead, which
is the skeleton profile for newly created users. By doing so, we do not
rely on the naming of the build user