### PR TITLE
Make docker-compose SELinux compatible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,5 @@ services:
       - KAS_WORK_DIR=/mnt/yocto-kas
       - KAS_BUILD_DIR=$${KAS_WORK_DIR}/build
     volumes:
-      - ./:/mnt/yocto-kas
-      - ~/.ssh:/builder/.ssh
+      - ./:/mnt/yocto-kas:z
+      - ~/.ssh:/builder/.ssh:z


### PR DESCRIPTION
In order to mount volumes into a Docker container with SELinux enabled
on the Hostsystem, we need to add ":Z" to the volume mount, as to proper
label the volume content mounted into a container