### PR TITLE
Move seldom used targets into separate kas config

### DIFF
--- a/kas-additional-targets.yml
+++ b/kas-additional-targets.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2021 iris-GmbH infrared & intelligent sensors
+
+header:
+  version: 9
+
+target:
+  - multiconfig:sc572-gen6
+  - multiconfig:sc573-ezkit
+  - multiconfig:sc573-gen6-4dvein

--- a/kas-irma6-base.yml
+++ b/kas-irma6-base.yml
@@ -7,10 +7,7 @@ header:
 distro: "poky-iris"
 
 target:
-  - multiconfig:sc572-gen6
-  - multiconfig:sc573-ezkit
   - multiconfig:sc573-gen6
-  - multiconfig:sc573-gen6-4dvein
   - multiconfig:imx8mp-evk
 
 repos:


### PR DESCRIPTION
Reducing the number of targets drastically reduces the time yocto spends
on parsing recipes. This commit moves seldom used targets from the main
kas config file into a separate config file.