### PR TITLE
Move DISTRO_VERSION declaration to KAS repository

### DIFF
--- a/kas-irma6-base.yml
+++ b/kas-irma6-base.yml
@@ -75,6 +75,7 @@ bblayers_conf_header:
 local_conf_header:
   standard: |
     CONF_VERSION = "1"
+    IRMA6_DISTRO_VERSION = "1.1.26-dev"
 
   default_cache_dirs: |
     DL_DIR ?= "${TOPDIR}/dl_dir"


### PR DESCRIPTION
As the KAS repository is responsible for the overall versioning, the
DISTRO_VERSION should be defined there as well. Unfortunately, it is not
possible to set the variable outside of the distro config, however one
can refer to the value of an arbitrary variable from the local configs global
scope.