### PR TITLE
Add new ros-common dependency

### DIFF
--- a/kas-irma6-base.yml
+++ b/kas-irma6-base.yml
@@ -32,6 +32,7 @@ repos:
     refspec: "dunfell"
     layers:
       meta-ros-backports-gatesgarth:
+      meta-ros-backports-hardknott:
       meta-ros-common:
 
   # repos relevant for testing


### PR DESCRIPTION
Since commit
https://github.com/ros/meta-ros/commit/ed0fce246bed1bb417307935d871ec1c2554354d
ros-common now also depends on ros-backports-hardknott-layer.