### PR TITLE
kas-offline-build.yml: Remove hardcoded variable

### DIFF
--- a/kas-offline-build.yml
+++ b/kas-offline-build.yml
@@ -6,6 +6,6 @@ header:
 
 local_conf_header:
   offline_build: |
-    SOURCE_MIRROR_URL ?= "file://${TOPDIR}/dl_dir"
+    SOURCE_MIRROR_URL ?= "file://${DL_DIR}"
     INHERIT += "own-mirrors"
     BB_NO_NETWORK = "1"


### PR DESCRIPTION
Use KAS' DL_DIR variable instead:
https://kas.readthedocs.io/en/latest/command-line.html#environment-variables