### PR TITLE
Install QEMU from backports for bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
 FROM ghcr.io/siemens/kas/kas:2.5
 
 RUN set -ex \
+# Add buster-backports to repos
+    && echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list \
     && apt-get update \
+# Install QEMU deps (TAP devices)
     && apt-get install --no-install-recommends -y \
         iptables \
-        qemu-system \
+    \
+# Install QEMU from backports (more recent version for bugfixes)
+    && apt-get install --no-install-recommends -y -t buster-backports qemu-system \
+# No upgrades for qemu
+    && apt-mark hold qemu-system \
     && rm -rf /var/lib/apt/lists
+# Print QEMU version
+RUN qemu-system-aarch64 --version


### PR DESCRIPTION
QEMU 3.x networking does not work properly in docker, therefore upgraded QEMU to 5.2 from debian backports. 

xref: DEVOPS-153