### PR TITLE
Codebuild: Fix cache population

### DIFF
--- a/buildspecs/build_firmware_images_develop.yml
+++ b/buildspecs/build_firmware_images_develop.yml
@@ -14,13 +14,13 @@ phases:
       # set target images
       - export images="$(for i in ${IMAGES}; do echo -n "mc:${MULTI_CONF}:${i} "; done)"
       # clone layer repos and try to checkout the current branch name in all meta layers
-      - kas for-all-repos --update kas-irma6-pa.yml:include/kas-irma6-jenkins-develop.yml "git checkout ${GIT_BRANCH} 2> /dev/null || true"
+      # populate sstate on builds of iris-kas develop branches
+      - "if [ \"${JOB_NAME}\" = \"iris-kas-develop\" ] && [ \"$(basename ${GIT_BRANCH})\" = \"develop\" ]; then echo \"Info: Populating caches...\" && export POPULATE_CACHES=\":include/kas-irma6-jenkins-populate-caches.yml\"; fi"
+      - kas for-all-repos --update kas-irma6-pa.yml:include/kas-irma6-jenkins-develop.yml${POPULATE_CACHES} "git checkout ${GIT_BRANCH} 2> /dev/null || true"
 
   build:
     on-failure: ABORT
     commands:
-      # populate sstate on builds of iris-kas develop branches
-      - if [ "${JOB_NAME}" = "iris-kas-develop" ] && [ "$(basename ${GIT_BRANCH})" = "develop" ]; then export POPULATE_CACHES=":include/kas-irma6-jenkins-populate-caches.yml"; fi
       # build artifacts
       - kas shell -k -c "bitbake ${images}" kas-irma6-pa.yml:include/kas-irma6-${MULTI_CONF}.yml:include/kas-irma6-jenkins-develop.yml${POPULATE_CACHES}
       - kas shell -k -c "bitbake mc:${MULTI_CONF}:${SDK_IMAGE} -c populate_sdk" kas-irma6-pa.yml:include/kas-irma6-${MULTI_CONF}.yml:include/kas-irma6-jenkins-develop.yml${POPULATE_CACHES}


### PR DESCRIPTION
As the "-k" option is used within the latter KAS commands, the
configuration is not actually updated, if the cache population
conditions are met. Therefore this is now validated before the first,
config-relevant kas execution.