### PR TITLE
Jenkins: Do not checkout PR branch on layer repos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,8 @@ pipeline {
                 script {
                     env.GIT_TAG = sh(script: 'git describe --tag --exact-match 2> /dev/null || true', returnStdout: true).trim()
                     env.ARTIFACT_NAME = sh(script: "if [ -n \"${GIT_TAG}\" ]; then echo \"${GIT_TAG}\"; else echo \"${GIT_COMMIT}\"; fi", returnStdout: true).trim()
+                    // if this is a PR branch, the env variable "CHANGE_BRANCH" will contain the real branch name, which we need for checkout later on
+                    env.REAL_GIT_BRANCH = sh(script: "if [ -n \"${CHANGE_BRANCH}\" ]; then echo \"${CHANGE_BRANCH}\"; else echo \"${GIT_BRANCH}\"; fi", returnStdout: true).trim()
                 }
                 // manually upload kas sources to S3, as to prevent upload conflicts in parallel steps
                 zip dir: '', zipFile: 'iris-kas-sources.zip'
@@ -69,7 +71,7 @@ pipeline {
                                 sourceControlType: 'project',
                                 sourceTypeOverride: 'S3',
                                 sourceLocationOverride: "${S3_BUCKET}/${JOB_NAME}/${GIT_COMMIT}/iris-kas-sources.zip",
-                                envVariables: "[ { MULTI_CONF, $MULTI_CONF }, { IMAGES, $IMAGES }, { SDK_IMAGE, $SDK_IMAGE }, { HOME, /home/builder }, { JOB_NAME, $JOB_NAME }, { GIT_BRANCH, $GIT_BRANCH } ]"
+                                envVariables: "[ { MULTI_CONF, $MULTI_CONF }, { IMAGES, $IMAGES }, { SDK_IMAGE, $SDK_IMAGE }, { HOME, /home/builder }, { JOB_NAME, $JOB_NAME }, { GIT_BRANCH, $REAL_GIT_BRANCH } ]"
                         }
                     }
                 }
@@ -214,7 +216,7 @@ pipeline {
                             sourceControlType: 'project',
                             sourceTypeOverride: 'S3',
                             sourceLocationOverride: "${S3_BUCKET}/${JOB_NAME}/${GIT_COMMIT}/iris-kas-sources.zip",
-                            envVariables: "[ { GIT_BRANCH, $GIT_BRANCH } ]"
+                            envVariables: "[ { GIT_BRANCH, $REAL_GIT_BRANCH } ]"
                     }
                 }
 

--- a/buildspecs/build_firmware_images_develop.yml
+++ b/buildspecs/build_firmware_images_develop.yml
@@ -15,9 +15,10 @@ phases:
       - export images="$(for i in ${IMAGES}; do echo -n "mc:${MULTI_CONF}:${i} "; done)"
       # populate sstate on daily builds of iris-kas-develop
       - "if [ \"${JOB_NAME}\" = \"iris-kas-develop\" ]; then echo \"Info: Populating caches...\" && export POPULATE_CACHES=\":include/kas-irma6-jenkins-populate-caches.yml\"; fi"
-      # clone layer repos and try to checkout the current branch name in all meta layers
+      # clone layer repos
       - kas checkout --update kas-irma6-pa.yml:include/kas-irma6-${MULTI_CONF}.yml:include/kas-irma6-jenkins-develop.yml${POPULATE_CACHES}
-      - "if [ \"$(basename ${GIT_BRANCH})\" != \"develop\" ] && [ \"$(basename ${GIT_BRANCH})\" != \"master\" ]; then kas for-all-repos kas-irma6-pa.yml:include/kas-irma6-${MULTI_CONF}.yml:include/kas-irma6-jenkins-develop.yml${POPULATE_CACHES} \"git checkout ${GIT_BRANCH} 2> /dev/null || true\"; fi"
+      # try to checkout the current feature/bugfix/... branch in all iris meta layers
+      - "if [ \"$(basename ${GIT_BRANCH})\" != \"develop\" ] && [ \"$(basename ${GIT_BRANCH})\" != \"master\" ]; then kas for-all-repos kas-irma6-pa.yml:include/kas-irma6-${MULTI_CONF}.yml:include/kas-irma6-jenkins-develop.yml${POPULATE_CACHES} \"if echo \\${KAS_REPO_NAME} | grep -qE '.*iris.*'; then echo \\\"Info: Trying to checkout ${GIT_BRANCH} in \\${KAS_REPO_NAME}\\\"; git checkout ${GIT_BRANCH} 2>/dev/null && echo \\\"Info: Branch ${GIT_BRANCH} has been checked out in \\${KAS_REPO_NAME}\\\" || echo \\\"Info: Branch ${GIT_BRANCH} not found in \\${KAS_REPO_NAME}\\\"; fi\"; fi"
 
   build:
     on-failure: ABORT


### PR DESCRIPTION
As the PR branch within jenkins does not contain the actual
branch name, this will not lead to the expected result when trying to
checkout the same branch in the layer repos.