### PR TITLE
Enable adding patch files to KAS repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ start-release: git-flow
 	@[ -n "$(TAG)" ] || { echo "Error: Please specify the TAG variable" >&2; exit 1; }
 	git flow release start --showcommands $(TAG) develop
 	@echo "Info: Setting fixed refspecs on layer repos for you..."
-	$(KAS_COMMAND) for-all-repos kas-irma6-pa.yml 'if [ "$$(echo $${KAS_REPO_NAME})" = "meta-iris" ]; then yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --always)\"" -i ../kas-irma6-pa.yml; else yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --always)\"" -i ../kas-irma6-base.yml; fi'
+	$(KAS_COMMAND) for-all-repos kas-irma6-pa.yml 'if [ "$${KAS_REPO_NAME}" = "meta-iris" ]; then yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --always)\"" -i ../kas-irma6-pa.yml; elif [ "$${KAS_REPO_NAME}" != "this" ]; then yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --always)\"" -i ../kas-irma6-base.yml; fi'
 	git add -A
 	git commit -m "Set fixed repo refspecs for release $(TAG)"
 	@echo "Warning: Please make sure you adjust "IRMA6_DISTRO_VERSION" in kas-irma6-base.yml and that the changelog is up-to-date before merging the release."
@@ -19,7 +19,7 @@ start-support: git-flow
 	@[ -n "$(TAG)" ] || { echo "Error: Please specify the TAG variable" >&2; exit 1; }
 	git flow support start --showcommands $(TAG) develop
 	@echo "Info: Setting fixed refspecs on layer repos for you..."
-	$(KAS_COMMAND) for-all-repos kas-irma6-pa.yml 'if [ "$$(echo $${KAS_REPO_NAME})" = "meta-iris" ]; then yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --always)\"" -i ../kas-irma6-pa.yml; else yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --always)\"" -i ../kas-irma6-base.yml; fi'
+	$(KAS_COMMAND) for-all-repos kas-irma6-pa.yml 'if [ "$${KAS_REPO_NAME}" = "meta-iris" ]; then yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --always)\"" -i ../kas-irma6-pa.yml; elif [ "$${KAS_REPO_NAME} != "this" ]; then yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --always)\"" -i ../kas-irma6-base.yml; fi'
 	git add -A
 	git commit -m "Set fixed repo refspecs for support release $(TAG)"
 	@echo "Warning: Please make sure you adjust "IRMA6_DISTRO_VERSION" in kas-irma6-base.yml and that the changelog is up-to-date before tagging the support release."

--- a/buildspecs/build_firmware_images_release.yml
+++ b/buildspecs/build_firmware_images_release.yml
@@ -12,7 +12,7 @@ phases:
       # make sure ownership of mounted EFS volumes is correct
       - sudo chown builder:builder /mnt/yocto_cache/dl_dir /mnt/yocto_cache/sstate_cache /mnt/yocto_cache/sstate_release_cache
       - "echo Info: Making sure fixed refspecs are set..."
-      - "kas for-all-repos kas-irma6-pa.yml 'git rev-parse --abbrev-ref HEAD | grep -qE \"^HEAD\\s*$\" || { echo \"Error: Non-fixed refspec detected in repo ${KAS_REPO_NAME}. Please set to a git commit hash or tag for a release build\"; exit 1; }'"
+      - "kas for-all-repos kas-irma6-pa.yml 'if [ \"${KAS_REPO_NAME}\" != \"this\" ]; then git rev-parse --abbrev-ref HEAD | grep -qE \"^HEAD\\s*$\" || { echo \"Error: Non-fixed refspec detected in repo ${KAS_REPO_NAME}. Please set to a git commit hash or tag for a release build\"; exit 1; }; fi'"
       # set target images
       - export images="$(for i in ${IMAGES}; do echo -n "mc:${MULTI_CONF}:${i} "; done)"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,0 +1,1 @@
+# enables adding the iris-kas repo as "this" to the KAS config

--- a/kas-irma6-base.yml
+++ b/kas-irma6-base.yml
@@ -17,7 +17,15 @@ local_conf_header:
     # adjust on release and reintegrate
     IRMA6_DISTRO_VERSION = "2.0.0-dev"
 
+defaults:
+  repos:
+    patches:
+      repo: "this"
+
 repos:
+  # the iris-kas repo
+  this:
+    path: ""
   # iris-specific repos
   meta-iris-base:
     url: "https://github.com/iris-GmbH/meta-iris-base.git"


### PR DESCRIPTION
Previously, files for patching one of the yocto layer repositories had
to added within another yocto layer repository. This commit prepares the
KAS repository for adding patches directly within the KAS repository.
Existing tooling as been adapted for the inclusion of the "this"
repository.

As a side effect, the KAS repository is now also added to the yocto
BBLAYERS. This however does not seem to have a negative effect.