### PR TITLE
jenkins: Reduce number of parallel BB threads

### DIFF
--- a/include/kas-irma6-jenkins-develop.yml
+++ b/include/kas-irma6-jenkins-develop.yml
@@ -6,3 +6,7 @@ header:
   includes:
     - "kas-dl-mirror.yml"
     - "kas-sstate-mirror.yml"
+
+local_conf_header:
+  bb_threads_number: |
+    BB_NUMBER_THREADS = "4"

--- a/include/kas-irma6-jenkins-release.yml
+++ b/include/kas-irma6-jenkins-release.yml
@@ -14,3 +14,6 @@ local_conf_header:
   build_history: |
     INHERIT += "buildhistory"
     BUILDHISTORY_COMMIT = "1"
+
+  bb_threads_number: |
+    BB_NUMBER_THREADS = "4"


### PR DESCRIPTION
Builds in AWS codebuild would sometimes run into OOM issues. Reducing
the number of parallel BB threads should solve this issue.