### PR TITLE
Fix whitespace and trailing newline warnings

### DIFF
--- a/patches/0001-Add-recipe-for-repo-2.16.7.patch
+++ b/patches/0001-Add-recipe-for-repo-2.16.7.patch
@@ -1,24 +1,24 @@
-From 20bbb4af4ac9f97be5ed0aec8968fee9237b6dc3 Mon Sep 17 00:00:00 2001
+From f7b72b52c63bb51d6333f9aa77502b013b5197c2 Mon Sep 17 00:00:00 2001
 From: Jasper Orschulko <Jasper.Orschulko@iris-sensing.com>
-Date: Fri, 17 Sep 2021 15:03:21 +0200
+Date: Sun, 10 Oct 2021 16:17:45 +0000
 Subject: [PATCH] Add recipe for repo 2.16.7
 
 Signed-off-by: Jasper Orschulko <Jasper.Orschulko@iris-sensing.com>
 ---
- .../repo/files/0001-python3-shebang.patch     | 22 ++++++++++++++++
+ .../repo/files/0001-python3-shebang.patch     | 21 ++++++++++++++++
  meta-oe/recipes-devtools/repo/repo.inc        | 25 +++++++++++++++++++
  meta-oe/recipes-devtools/repo/repo_2.16.7.bb  |  7 ++++++
- 3 files changed, 54 insertions(+)
+ 3 files changed, 53 insertions(+)
  create mode 100644 meta-oe/recipes-devtools/repo/files/0001-python3-shebang.patch
  create mode 100644 meta-oe/recipes-devtools/repo/repo.inc
  create mode 100644 meta-oe/recipes-devtools/repo/repo_2.16.7.bb
 
 diff --git a/meta-oe/recipes-devtools/repo/files/0001-python3-shebang.patch b/meta-oe/recipes-devtools/repo/files/0001-python3-shebang.patch
 new file mode 100644
-index 000000000..3dcf6ef6e
+index 000000000..09ccf5826
 --- /dev/null
 +++ b/meta-oe/recipes-devtools/repo/files/0001-python3-shebang.patch
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,21 @@
 +From b8e84b202cd302a7c99288d3835dc9c63071f8f2 Mon Sep 17 00:00:00 2001
 +From: Jasper Orschulko <Jasper.Orschulko@iris-sensing.com>
 +Date: Tue, 14 Sep 2021 16:46:51 +0200
@@ -38,9 +38,8 @@ index 000000000..3dcf6ef6e
 + # -*- coding:utf-8 -*-
 + #
 + # Copyright (C) 2008 The Android Open Source Project
-+-- 
++--
 +2.33.0
-+
 diff --git a/meta-oe/recipes-devtools/repo/repo.inc b/meta-oe/recipes-devtools/repo/repo.inc
 new file mode 100644
 index 000000000..60b32e4d7
@@ -85,6 +84,5 @@ index 000000000..377091c53
 +
 +SRCREV = "1328c35a4d0b47c7e8c00fe351f0e587481e28c2"
 +LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
--- 
-2.33.0
-
+--
+2.20.1


### PR DESCRIPTION
Fix warnings during apply of repo patch, which could cause confusion as KAS
would falsely label them as errors.