### PR TITLE
jenkins: Do not try to checkout release branches

### DIFF
--- a/buildspecs/build_firmware_images_develop.yml
+++ b/buildspecs/build_firmware_images_develop.yml
@@ -22,7 +22,7 @@ phases:
       - kas checkout --update kas-irma6-pa.yml:include/kas-irma6-${MULTI_CONF}.yml:include/kas-irma6-jenkins-develop.yml${POPULATE_CACHES}
       # try to checkout the current feature/bugfix/... branch in all iris meta layers
       - >
-          if [ "$(basename ${GIT_BRANCH})" != "develop" ] && [ "$(basename ${GIT_BRANCH})" != "master" ]; then
+          if [ "$(basename ${GIT_BRANCH})" != "develop" ] && [ "$(basename ${GIT_BRANCH})" != "master" ] && $(echo "${GIT_BRANCH}" | grep -vqE '^release/.*'); then
             kas for-all-repos kas-irma6-pa.yml:include/kas-irma6-${MULTI_CONF}.yml:include/kas-irma6-jenkins-develop.yml${POPULATE_CACHES} "if echo \${KAS_REPO_NAME} | grep -qE '.*iris.*'; then echo \"Info: Trying to checkout ${GIT_BRANCH} in \${KAS_REPO_NAME}\"; git checkout ${GIT_BRANCH} 2>/dev/null && echo \"Info: Branch ${GIT_BRANCH} has been checked out in \${KAS_REPO_NAME}\" || echo \"Info: Branch ${GIT_BRANCH} not found in \${KAS_REPO_NAME}\"; fi";
           fi
   build:


### PR DESCRIPTION
Fixes a bug, which would try to checkout an identical named branch when
running from a release branch.