### PR TITLE
Dockerfile: Fixed refspec 2.6.1 for kas base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # type can be set to jenkins. Override with "--build-arg type=jenkins" during build
 ARG type=base
 
-ARG KAS_VER=next
+ARG KAS_VER=2.6.1
 ARG REPO_REV=v2.17.2
 ARG YQ_REV=v4.13.5
 


### PR DESCRIPTION
There has been a recent release of the KAS software, 2.6.1, which
contains the following necessary fixes for our CI setup:

https://github.com/siemens/kas/commit/15de0142d48cdc8e49507081650b3c25c851b00b
https://github.com/siemens/kas/commit/9732ec16f23fb2b8e9537f5d6f495b2ac8470225

We can therefore set our image to use this release, instead of the
latest development build.