### PR TITLE
Dockerfile: Add cmake to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2021 iris-GmbH infrared & intelligent sensors
 
-# TYPE can be set to jenkins. Override with "--build-arg type=jenkins" during build
+# type can be set to jenkins. Override with "--build-arg type=jenkins" during build
 ARG type=base
+
+ARG KAS_VER=next
 ARG REPO_REV=v2.17.2
 ARG YQ_REV=v4.13.5
 
@@ -20,7 +22,7 @@ RUN set -ex \
     && git clone --single-branch -b ${REPO_REV} https://android.googlesource.com/tools/repo /repo \
     && chmod +x /repo/repo
 
-FROM ghcr.io/siemens/kas/kas:next as base
+FROM ghcr.io/siemens/kas/kas:${KAS_VER} as base
 LABEL maintainer="Jasper Orschulko <Jasper.Orschulko@iris-sensing.com>"
 RUN set -ex \
     && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ RUN set -ex \
 
 FROM ghcr.io/siemens/kas/kas:next as base
 LABEL maintainer="Jasper Orschulko <Jasper.Orschulko@iris-sensing.com>"
+RUN set -ex \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
+        cmake \
+    && rm -rf /var/lib/apt/lists
 COPY --from=builder /yq/yq /usr/local/bin/yq
 COPY --from=builder /repo/repo /usr/local/bin/repo
 


### PR DESCRIPTION
We need cmake when interacting directly with the source code (e.g.
building PA using google repo and crosstoolchain).