### PR TITLE
[DEVOPS-390] Freeze poky layer due to gtest bug

### DIFF
--- a/kas-irma6-base.yml
+++ b/kas-irma6-base.yml
@@ -33,7 +33,7 @@ repos:
   # general repos
   poky:
     url: "https://git.yoctoproject.org/git/poky"
-    refspec: "dunfell"
+    refspec: "746b301d37f9b7333f3d93e6fb7ea2808665df41"
     layers:
       meta:
       meta-poky:


### PR DESCRIPTION
Commit [11d99fba1ff4da5b031e03c6504bc0e777615ac2](https://git.yoctoproject.org/poky/commit/?h=dunfell&id=11d99fba1ff4da5b031e03c6504bc0e777615ac2) in the poky layer
causes build errors when including gtest. Freeze poky refspec until this [issue
has been resolved](https://lists.openembedded.org/g/openembedded-core/topic/87483225#159473).