### PR TITLE
[DEVOPS-389] codebuild: Use single EFS mount

### DIFF
--- a/buildspecs/build_firmware_images_develop.yml
+++ b/buildspecs/build_firmware_images_develop.yml
@@ -9,8 +9,8 @@ phases:
   pre_build:
     on-failure: ABORT
     commands:
-      # make sure ownership of mounted EFS volumes is correct
-      - sudo chown builder:builder /mnt/yocto_cache/dl_dir /mnt/yocto_cache/sstate_cache
+      # make sure ownership of mounted EFS volume is correct
+      - sudo chown builder:builder /mnt/yocto_cache
       # set target images
       - export images="$(for i in ${IMAGES}; do echo -n "mc:${MULTI_CONF}:${i} "; done)"
       # populate sstate on daily builds of iris-kas-develop

--- a/buildspecs/build_firmware_images_release.yml
+++ b/buildspecs/build_firmware_images_release.yml
@@ -9,8 +9,8 @@ phases:
   pre_build:
     on-failure: ABORT
     commands:
-      # make sure ownership of mounted EFS volumes is correct
-      - sudo chown builder:builder /mnt/yocto_cache/dl_dir /mnt/yocto_cache/sstate_cache /mnt/yocto_cache/sstate_release_cache
+      # make sure ownership of mounted EFS volume is correct
+      - sudo chown builder:builder /mnt/yocto_cache
       - "echo Info: Making sure fixed refspecs are set..."
       - "kas for-all-repos kas-irma6-pa.yml 'if [ \"${KAS_REPO_NAME}\" != \"this\" ]; then git rev-parse --abbrev-ref HEAD | grep -qE \"^HEAD\\s*$\" || { echo \"Error: Non-fixed refspec detected in repo ${KAS_REPO_NAME}. Please set to a git commit hash or tag for a release build\"; exit 1; }; fi'"
       # set target images

--- a/buildspecs/license_compliance.yml
+++ b/buildspecs/license_compliance.yml
@@ -9,8 +9,8 @@ phases:
   pre_build:
     on-failure: ABORT
     commands:
-      # make sure ownership of mounted EFS volumes is correct
-      - sudo chown builder:builder /mnt/yocto_cache/dl_dir /mnt/yocto_cache/sstate_cache /mnt/yocto_cache/sstate_release_cache
+      # make sure ownership of mounted EFS volume is correct
+      - sudo chown builder:builder /mnt/yocto_cache
       # make sure sstate release cache is empty
       - "[ $(find /mnt/yocto_cache/sstate_release_cache -mindepth 1 | wc -l) -eq 0 ] || { echo \"Error: sstate release cache is not clean.\"; exit 1; }"
       - "echo Info: Making sure fixed refspecs are set..."

--- a/buildspecs/populate_download_mirror.yml
+++ b/buildspecs/populate_download_mirror.yml
@@ -9,8 +9,8 @@ phases:
   pre_build:
     on-failure: ABORT
     commands:
-      # ensure writability on dl mirror mount point
-      - sudo chown builder:builder /mnt/yocto_cache/dl_dir
+      # make sure ownership of mounted EFS volume is correct
+      - sudo chown builder:builder /mnt/yocto_cache
 
   build:
     on-failure: ABORT


### PR DESCRIPTION
Due to a bug in AWS, it is currently not possible to mount multiple EFSs
into a codebuild instance. As a workaround we consolidate these into a
single EFS, until this has been resolved in upstream.

Upstream bug tracked at:

- https://github.com/aws/efs-utils/issues/114
- https://repost.aws/questions/QUXUoUoVAPQoGIYfuPpB-s7A/codebuild-adding-multiple-efs-suddenly-failes