### PR TITLE
Makefile: Handle patches during refspec generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ start-release: git-flow
 	@[ -n "${TAG}" ] || { echo "Error: Please specify the TAG variable" >&2; exit 1; }
 	git flow release start --showcommands ${TAG} develop
 	@echo "Info: Setting fixed refspecs on thirdparty layer repos for you..."
-	${KAS_COMMAND} for-all-repos kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --long --always)\"" -i ../kas-irma6-base.yml; fi'
+	${KAS_COMMAND} for-all-repos kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then git checkout $${KAS_REPO_REFSPEC} && yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --long --always)\"" -i ../kas-irma6-base.yml; fi'
 	git add -A
 	git commit -m "Fixed refspecs on thirdparty layers for release ${TAG}"
 	@echo "Info: Please make sure you adjust "IRMA6_DISTRO_VERSION" in kas-irma6-base.yml, set fixed refspecs for iris layers and that the changelog is up-to-date before merging the release."
@@ -97,7 +97,7 @@ start-support: git-flow
 	@[ -n "${TAG}" ] || { echo "Error: Please specify the TAG variable" >&2; exit 1; }
 	git flow support start --showcommands ${TAG}
 	@echo "Info: Setting fixed refspecs on layer repos for you..."
-	${KAS_COMMAND} for-all-repos kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --long --always)\"" -i ../kas-irma6-base.yml; fi'
+	${KAS_COMMAND} for-all-repos kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then git checkout $${KAS_REPO_REFSPEC} && yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --long --always)\"" -i ../kas-irma6-base.yml; fi'
 	git add -A
 	git commit -m "Fixed refspecs on thirdparty layers for support release ${TAG}"
 	@echo "Info: Please make sure you adjust "IRMA6_DISTRO_VERSION" in kas-irma6-base.yml, set fixed refspecs for iris layers and that the changelog is up-to-date before tagging the support release."


### PR DESCRIPTION
The `start-release` and `start-support` targets would use the HEAD of
the git branch after running kas for generating the fixed refspecs.
However, this would not account for temporary patch commits added by
KAS. Thus we manually checkout the original refspec as defined in the
kas config file, before running git describe.