### PR TITLE
Makefile: Fix start-support target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ start-release: git-flow
 	@[ -n "${TAG}" ] || { echo "Error: Please specify the TAG variable" >&2; exit 1; }
 	git flow release start --showcommands ${TAG} develop
 	@echo "Info: Setting fixed refspecs on thirdparty layer repos for you..."
-	${KAS_COMMAND} for-all-repos kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then git checkout $${KAS_REPO_REFSPEC} && yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --long --always)\"" -i ../kas-irma6-base.yml; fi'
+	${KAS_COMMAND} for-all-repos --update kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then git checkout $${KAS_REPO_REFSPEC} && yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --long --always)\"" -i ../kas-irma6-base.yml; fi'
 	git add -A
 	git commit -m "Fixed refspecs on thirdparty layers for release ${TAG}"
 	@echo "Info: Please make sure you adjust "IRMA6_DISTRO_VERSION" in kas-irma6-base.yml, set fixed refspecs for iris layers and that the changelog is up-to-date before merging the release."
@@ -102,7 +102,7 @@ start-support: git-flow
 	@[ -n "${BASE_COMMIT}" ] || { echo "Error: Please specify the BASE_COMMIT variable. This is a commit on the master branch from which the support release shall be created." >&2; exit 1; }
 	git flow support start --showcommands ${TAG} ${BASE_COMMIT}}
 	@echo "Info: Setting fixed refspecs on layer repos for you..."
-	${KAS_COMMAND} for-all-repos kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then git checkout $${KAS_REPO_REFSPEC} && yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --long --always)\"" -i ../kas-irma6-base.yml; fi'
+	${KAS_COMMAND} for-all-repos --update kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then git checkout $${KAS_REPO_REFSPEC} && yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --long --always)\"" -i ../kas-irma6-base.yml; fi'
 	git add -A
 	git commit -m "Fixed refspecs on thirdparty layers for support release ${TAG}"
 	@echo "Info: Please make sure you adjust "IRMA6_DISTRO_VERSION" in kas-irma6-base.yml, set fixed refspecs for iris layers and that the changelog is up-to-date before tagging the support release."

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ start-release: git-flow
 	@[ -n "${TAG}" ] || { echo "Error: Please specify the TAG variable" >&2; exit 1; }
 	git flow release start --showcommands ${TAG} develop
 	@echo "Info: Setting fixed refspecs on thirdparty layer repos for you..."
-	${KAS_COMMAND} for-all-repos --update kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then git checkout $${KAS_REPO_REFSPEC} && yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --long --always)\"" -i ../kas-irma6-base.yml; fi'
+	${KAS_COMMAND} for-all-repos --update kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then git checkout $${KAS_REPO_REFSPEC} && yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git rev-parse --verify HEAD)\"" -i ../kas-irma6-base.yml; fi'
 	git add -A
 	git commit -m "Fixed refspecs on thirdparty layers for release ${TAG}"
 	@echo "Info: Please make sure you adjust "IRMA6_DISTRO_VERSION" in kas-irma6-base.yml, set fixed refspecs for iris layers and that the changelog is up-to-date before merging the release."
@@ -102,7 +102,7 @@ start-support: git-flow
 	@[ -n "${BASE_COMMIT}" ] || { echo "Error: Please specify the BASE_COMMIT variable. This is a commit on the master branch from which the support release shall be created." >&2; exit 1; }
 	git flow support start --showcommands ${TAG} ${BASE_COMMIT}}
 	@echo "Info: Setting fixed refspecs on layer repos for you..."
-	${KAS_COMMAND} for-all-repos --update kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then git checkout $${KAS_REPO_REFSPEC} && yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --long --always)\"" -i ../kas-irma6-base.yml; fi'
+	${KAS_COMMAND} for-all-repos --update kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then git checkout $${KAS_REPO_REFSPEC} && yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git rev-parse --verify HEAD)\"" -i ../kas-irma6-base.yml; fi'
 	git add -A
 	git commit -m "Fixed refspecs on thirdparty layers for support release ${TAG}"
 	@echo "Info: Please make sure you adjust "IRMA6_DISTRO_VERSION" in kas-irma6-base.yml, set fixed refspecs for iris layers and that the changelog is up-to-date before tagging the support release."

--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,9 @@ start-release: git-flow
 	@echo "Info: Please make sure you adjust "IRMA6_DISTRO_VERSION" in kas-irma6-base.yml, set fixed refspecs for iris layers and that the changelog is up-to-date before merging the release."
 
 start-support: git-flow
-	@[ -n "${TAG}" ] || { echo "Error: Please specify the TAG variable" >&2; exit 1; }
-	git flow support start --showcommands ${TAG}
+	@[ -n "${TAG}" ] || { echo "Error: Please specify the TAG variable. e.g. support/2.2.2-foo" >&2; exit 1; }
+	@[ -n "${BASE_COMMIT}" ] || { echo "Error: Please specify the BASE_COMMIT variable. This is a commit on the master branch from which the support release shall be created." >&2; exit 1; }
+	git flow support start --showcommands ${TAG} ${BASE_COMMIT}}
 	@echo "Info: Setting fixed refspecs on layer repos for you..."
 	${KAS_COMMAND} for-all-repos kas-irma6-pa.yml 'if echo "$${KAS_REPO_NAME}" | grep -vq "iris" && [ "$${KAS_REPO_NAME}" != "this" ]; then git checkout $${KAS_REPO_REFSPEC} && yq e ".repos.$${KAS_REPO_NAME}.refspec = \"$$(git describe --tags --long --always)\"" -i ../kas-irma6-base.yml; fi'
 	git add -A


### PR DESCRIPTION
The git flow support commands needs a base commit. This determines,
from which existing commit on the master branch shall be used as a basis
for the support release.
