### PR TITLE
Fix: qemux86-64 build: Ignore u-boot bbappend for meta-secure-imx

### DIFF
--- a/include/kas-irma6-base-config.yml
+++ b/include/kas-irma6-base-config.yml
@@ -60,3 +60,4 @@ local_conf_header:
     CSFK = "${HAB_DIR}/crts/CSF1_1_sha256_secp521r1_v3_usr_crt.pem"
     SIGN_CERT = "${HAB_DIR}/crts/IMG1_1_sha256_secp521r1_v3_usr_crt.pem"
     CRYPTO_HW_ACCEL = "CAAM"
+    BBMASK += "meta-secure-imx/recipes-bsp/u-boot/u-boot_%.bbappend"


### PR DESCRIPTION
The bbappend from meta-secure-imx's u-boot is not used at all. Since it
causes qemu build errors, it will be ignored from now on.

https://jenkins.devops.defra01.iris-sensing.net/blue/organizations/jenkins/iris-kas/detail/fix%2Fmigl%2Fquemux86-64_build/1/pipeline/