### PR TITLE
Fix: HAB_DIR point to the right dev_keys dir on cloud jenkins

### DIFF
--- a/include/kas-irma6-base-config.yml
+++ b/include/kas-irma6-base-config.yml
@@ -55,7 +55,7 @@ local_conf_header:
 
   meta-secure-imx: |
     HAB_ENABLE= "1"
-    HAB_DIR = "/mnt/yocto-kas/dev_keys"
+    HAB_DIR = "${TOPDIR}/../dev_keys"
     SRKTAB = "${HAB_DIR}/crts/SRK_1_2_3_4_table.bin"
     CSFK = "${HAB_DIR}/crts/CSF1_1_sha256_secp521r1_v3_usr_crt.pem"
     SIGN_CERT = "${HAB_DIR}/crts/IMG1_1_sha256_secp521r1_v3_usr_crt.pem"


### PR DESCRIPTION
Cloud jenkins does not use the docker-compose.yml. Adapt the HAB_DIR
path to point to the right location.