### PR TITLE
gitlab-ci: Move wipe stage to start of pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,12 +55,12 @@ default:
 
 # List of stages for jobs, and their order of execution
 stages:
+  - wipe
   - setup
   - build-base
   - build
   - build-deploy-distros
   - test
-  - wipe
 
 # Ensures that fixed refspecs are set for all meta-layers.
 # This is vital for build reproducibility.


### PR DESCRIPTION
Wipe should be able to run, even when all other jobs fail