### PR TITLE
[DEVOPS-553] Workaround force populating caches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,8 @@ variables:
   SSTATE_CACHE: "/mnt/yocto-sstate-cache"
   SSTATE_CACHE_RELEASE: "/mnt/yocto-sstate-cache-release"
   DOWNLOAD_MIRROR: "/mnt/yocto-download-mirror"
+  # force populating caches as workaround for https://jira.iris-sensing.net/browse/DEVOPS-553
+  FORCE_POPULATE_CACHES: "true"
   SKIP_SDK_BUILD:
     value: "true"
     description: 'Set to "false" to run the SDK build.'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,6 @@ stages:
   - setup
   - build-base
   - build
-  - build-deploy-distros
   - test
 
 # Ensures that fixed refspecs are set for all meta-layers.
@@ -178,7 +177,7 @@ release-build-sdk:
 release-build-deploy-distros:
   rules:
     - !reference [.release_template, rules]
-  stage: build-deploy-distros
+  stage: build
   parallel:
     matrix:
       - MULTI_CONF: [sc573-gen6]
@@ -290,7 +289,7 @@ develop-build-deploy-distro-targets:
     - if: '$SKIP_DEPLOY_TARGET_BUILD == "true"'
       when: never 
     - !reference [.develop_template, rules]
-  stage: build-deploy-distros
+  stage: build
   parallel:
     matrix:
     - MULTI_CONF: [sc573-gen6, imx8mp-evk, imx8mp-irma6r2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 ### Changed
 - [DEVOPS-519] Move basic config from local.conf to distro.conf in meta-iris
 - [DEVOPS-531] Split distro configs into deploy and maintenance
+- [DEVOPS-553] Use rw caches not only on develop branch. Workaround for long CI runs.
 
 
 ### Deprecated


### PR DESCRIPTION
Workaround for https://jira.iris-sensing.net/browse/DEVOPS-553. We force
populate the caches on other branches than develop. This should
drastically decrease CI runtime on feature branches.