### PR TITLE
Revert force populating caches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,8 +15,6 @@ variables:
   SSTATE_CACHE: "/mnt/yocto-sstate-cache"
   SSTATE_CACHE_RELEASE: "/mnt/yocto-sstate-cache-release"
   DOWNLOAD_MIRROR: "/mnt/yocto-download-mirror"
-  # force populating caches as workaround for https://jira.iris-sensing.net/browse/DEVOPS-553
-  FORCE_POPULATE_CACHES: "true"
   SKIP_SDK_BUILD:
     value: "true"
     description: 'Set to "false" to run the SDK build.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [APR's Version Numbering](https://apr.apache.org/ver
 ### Changed
 - [DEVOPS-519] Move basic config from local.conf to distro.conf in meta-iris
 - [DEVOPS-531] Split distro configs into deploy and maintenance
-- [DEVOPS-553] Use rw caches not only on develop branch. Workaround for long CI runs.
 
 
 ### Deprecated


### PR DESCRIPTION
After internal discussions it was agreed that the risks of
having outdated branches writing to cache, thus risking the integrity of
the sstate cache outweight the possible benefits.