### PR TITLE
Add pango to icecc blacklist

### DIFF
--- a/include/ci/kas-ci-common.yml
+++ b/include/ci/kas-ci-common.yml
@@ -11,3 +11,4 @@ local_conf_header:
     PRSERV_HOST = "yocto-prservice.yocto-prservice:8585"
   icecc: |
     INHERIT += "icecc"
+    ICECC_USER_PACKAGE_BL += "pango"


### PR DESCRIPTION
Apparently there are issues when building pango using icecc.