### PR TITLE
Remove meta-ros layers

### DIFF
--- a/kas-irma6-base-common.yml
+++ b/kas-irma6-base-common.yml
@@ -54,13 +54,6 @@ repos:
     patches:
       0001-add-repo-recipe:
         path: "patches/0001-Add-recipe-for-repo-2.19.patch"
-  meta-ros: # provides yaml-cpp
-    url: "https://github.com/ros/meta-ros.git"
-    refspec: "dunfell"
-    layers:
-      meta-ros-backports-gatesgarth:
-      meta-ros-backports-hardknott:
-      meta-ros-common:
   meta-swupdate:
     url: "https://github.com/sbabic/meta-swupdate"
     refspec: "dunfell"


### PR DESCRIPTION
Meta-ros is unmaintained since december 2021. Necessary packages are
migrated.