### PR TITLE
gitlab-ci: Remove manual trigger for wipe sstate cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ variables:
   DOWNLOAD_MIRROR: "/mnt/yocto-download-mirror"
   ICECREAM_NETNAME: "ICECREAM"
   RUN_MAINTENANCE: "false"
+  WIPE_SSTATE_CACHE: "false"
   SKIP_SDK_BUILD:
     value: "true"
     description: 'Set to "false" to run the SDK build.'
@@ -99,8 +100,9 @@ container-build:
 wipe-sstate-caches:
   stage: wipe
   rules:
+    - if: '$WIPE_SSTATE_CACHE == "false"'
+      when: never 
     - !reference [.develop_template, rules]
-  when: manual
   script:
     - find ${SSTATE_CACHE} ${SSTATE_CACHE_RELEASE} -mindepth 1 -delete
 


### PR DESCRIPTION
Instead, a variable can be defined if needed.