### PR TITLE
gitlab: Rework artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ variables:
   ICECREAM_NETNAME: "ICECREAM"
   RUN_MAINTENANCE: "false"
   WIPE_SSTATE_CACHE: "false"
+  FAILURE_LOG_DIR: "failure-log"
   SKIP_SDK_BUILD:
     value: "true"
     description: 'Set to "false" to run the SDK build.'
@@ -192,8 +193,10 @@ release-build-maintenance-distros:
     - !reference [.release_template, script, populate-dl-dir]
     - !reference [.release_template, script, create-source-artifact]
     - !reference [.release_template, script, build]
-    - !reference [.common_template, script, create-deploy-artifact]
-  artifacts: !reference [.release_template, artifacts, release-deploy-artifacts]
+  after_script:
+    - !reference [.common_template, after_script, remove-symbolic-image-links]
+    - !reference [.common_template, after_script, move-artifacts-to-toplevel]
+  artifacts: !reference [.release_template, artifacts, release-artifacts]
 
 release-build-qemu:
   rules:
@@ -210,10 +213,9 @@ release-build-qemu:
     - !reference [.common_template, script, generate-build-targets-other]
     - !reference [.release_template, script, populate-dl-cache]
     - !reference [.release_template, script, populate-dl-dir]
-    - !reference [.release_template, script, create-source-artifact]
+    - !reference [.common_template, script, create-artifact]
     - !reference [.release_template, script, build]
-    - !reference [.common_template, script, create-deploy-artifact]
-  artifacts: !reference [.release_template, artifacts, release-deploy-artifacts]
+  artifacts: !reference [.release_template, artifacts, release-qemu-artifacts]
 
 release-build-sdk:
   rules:
@@ -232,7 +234,8 @@ release-build-sdk:
     - !reference [.common_template, script, generate-build-targets-other]
     - !reference [.release_template, script, populate-dl-dir]
     - !reference [.release_template, script, build]
-    - !reference [.common_template, script, create-sdk-artifact]
+  after_script:
+    - !reference [.common_template, after_script, move-artifacts-to-toplevel]
   artifacts: !reference [.release_template, artifacts, release-sdk-artifacts]
 
 
@@ -258,8 +261,10 @@ release-build-deploy-distros:
     - !reference [.release_template, script, populate-dl-dir]
     - !reference [.release_template, script, create-source-artifact]
     - !reference [.release_template, script, build]
-    - !reference [.common_template, script, create-deploy-artifact]
-  artifacts: !reference [.release_template, artifacts, release-deploy-artifacts]
+  after_script:
+    - !reference [.common_template, after_script, remove-symbolic-image-links]
+    - !reference [.common_template, after_script, move-artifacts-to-toplevel]
+  artifacts: !reference [.release_template, artifacts, release-artifacts]
 
 release-test-qemu:
   stage: test
@@ -326,8 +331,10 @@ develop-build-maintenance-distro-targets:
     - !reference [.common_template, script, generate-build-targets-target]
     - !reference [.develop_template, script, build-configuration]
     - !reference [.develop_template, script, build]
-    - !reference [.common_template, script, create-deploy-artifact]
-  artifacts: !reference [.develop_template, artifacts, develop-deploy-artifacts]
+  after_script:
+    - !reference [.common_template, after_script, remove-symbolic-image-links]
+    - !reference [.common_template, after_script, move-artifacts-to-toplevel]
+  artifacts: !reference [.develop_template, artifacts, develop-artifacts]
 
 develop-build-deploy-distro-targets:
   rules:
@@ -346,8 +353,10 @@ develop-build-deploy-distro-targets:
     - !reference [.common_template, script, generate-build-targets-target]
     - !reference [.develop_template, script, build-configuration]
     - !reference [.develop_template, script, build]
-    - !reference [.common_template, script, create-deploy-artifact]
-  artifacts: !reference [.develop_template, artifacts, develop-deploy-artifacts]
+  after_script:
+    - !reference [.common_template, after_script, remove-symbolic-image-links]
+    - !reference [.common_template, after_script, move-artifacts-to-toplevel]
+  artifacts: !reference [.develop_template, artifacts, develop-artifacts]
 
 develop-build-qemu:
   rules:
@@ -367,8 +376,8 @@ develop-build-qemu:
     - !reference [.common_template, script, generate-build-targets-other]
     - !reference [.develop_template, script, build-configuration]
     - !reference [.develop_template, script, build]
-    - !reference [.common_template, script, create-deploy-artifact]
-  artifacts: !reference [.develop_template, artifacts, develop-deploy-artifacts]
+    - !reference [.common_template, script, create-artifact]
+  artifacts: !reference [.develop_template, artifacts, develop-qemu-artifacts]
 
 develop-build-sdk:
   rules:
@@ -390,7 +399,8 @@ develop-build-sdk:
     - !reference [.common_template, script, generate-build-targets-other]
     - !reference [.develop_template, script, build-configuration]
     - !reference [.develop_template, script, build]
-    - !reference [.common_template, script, create-sdk-artifact]
+  after_script:
+    - !reference [.common_template, after_script, move-artifacts-to-toplevel]
   artifacts: !reference [.develop_template, artifacts, develop-sdk-artifacts]
 
 develop-test-qemu:

--- a/.gitlab/common-template.yml
+++ b/.gitlab/common-template.yml
@@ -3,13 +3,10 @@
 
 .common_template:
   script:
-    create-deploy-artifact:
-      # create a tar.gz for archiving the deploy artifacts
+    create-artifact:
+      # create a tar.gz for archiving the yocto "deploy" folder. Useful, when linux permissions need to be preserved.
+      - sync
       - tar -I "gzip --best" -C build/tmp -cf ${MULTI_CONF}-deploy.tar.gz deploy
-
-    create-sdk-artifact:
-      # create a tar.gz for archiving the sdk artifacts
-      - tar -I "gzip --best" -C build/tmp/deploy -cf ${MULTI_CONF}-sdk.tar.gz sdk
 
     # Generates bitbake build targets.
     # required vars: MULTI_CONF, IMAGES
@@ -30,6 +27,15 @@
         fi
     generate-build-targets-other:
         export BUILD_TARGETS="$(for i in ${IMAGES}; do echo -n "mc:${MULTI_CONF}:${i} "; done)"
+
+  after_script:
+    # remove symbolic shortlinks to image build artifacts, as these do not work on Windows machines and just cause confusion
+    remove-symbolic-image-links:
+      - find build/tmp/deploy/images -type l -exec rm -f {} \;
+    # move artifacts to toplevel, see: https://gitlab.com/gitlab-org/gitlab-runner/-/issues/1057
+    move-artifacts-to-toplevel:
+      - mv build/tmp/deploy artifacts
+
   services:
     icecc-daemon:
       - name: $BUILD_IMAGE

--- a/.gitlab/develop-template.yml
+++ b/.gitlab/develop-template.yml
@@ -54,15 +54,33 @@
     build:
       - echo "Building ${BUILD_TARGETS}..."
       # build target images
-      - kas shell -c "bitbake ${NO_SETSCENE} ${BITBAKE_TASK} ${BUILD_TARGETS}" ${MAIN_KAS_FILES}:include/kas-irma6-${MULTI_CONF}.yml:include/ci/kas-ci-develop.yml${POPULATE_CACHES}
+      - >
+        if ! kas shell -c "bitbake ${NO_SETSCENE} ${BITBAKE_TASK} ${BUILD_TARGETS}" ${MAIN_KAS_FILES}:include/kas-irma6-${MULTI_CONF}.yml:include/ci/kas-ci-develop.yml${POPULATE_CACHES}; then
+          echo "Error during build. Creating log artifact..."
+          mkdir ${FAILURE_LOG_DIR}
+          find build/tmp/work -type f '(' -name "log.do_*" -o -name "log.task_order" ')' -exec rsync -R {} "${FAILURE_LOG_DIR}" \;
+          exit 1
+        fi
   artifacts:
-    develop-deploy-artifacts:
+    develop-artifacts:
+      name: "irma6-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-${MULTI_CONF}"
+      # currently no support for seperate "on-failure" and "on-success" artifact sections: https://gitlab.com/gitlab-org/gitlab/-/issues/18744
+      when: always
       paths:
-        - "${MULTI_CONF}-deploy.tar.gz"
+        - "artifacts"
+        - "${FAILURE_LOG_DIR}"
       untracked: false
       expire_in: 7 days
     develop-sdk-artifacts:
+      name: "irma6-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-${MULTI_CONF}-sdk"
+      # currently no support for seperate "on-failure" and "on-success" artifact sections: https://gitlab.com/gitlab-org/gitlab/-/issues/18744
+      when: always
       paths:
-        - "${MULTI_CONF}-sdk.tar.gz"
+        - "artifacts"
+        - "${FAILURE_LOG_DIR}"
       untracked: false
       expire_in: 7 days
+    develop-qemu-artifacts:
+      name: "irma6-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-${MULTI_CONF}-qemu"
+      paths:
+        - "${MULTI_CONF}-deploy.tar.gz"

--- a/.gitlab/release-template.yml
+++ b/.gitlab/release-template.yml
@@ -53,15 +53,22 @@
       - kas shell -c "bitbake ${BITBAKE_TASK} ${BUILD_TARGETS}" ${MAIN_KAS_FILES}:include/kas-irma6-${MULTI_CONF}.yml:include/ci/kas-ci-release.yml:include/kas-offline-build.yml
   artifacts:
     release-source-artifacts:
+      name: "irma6-${CI_COMMIT_TAG}-${MULTI_CONF}-base-sources"
       paths:
         - "${MULTI_CONF}-base-sources.tar.gz"
       untracked: false
       expire_in: 20 yrs
-    release-deploy-artifacts:
+    release-artifacts:
+      name: "irma6-${CI_COMMIT_TAG}-${MULTI_CONF}"
       paths:
-        - "${MULTI_CONF}-deploy.tar.gz"
+        - "artifacts"
       untracked: false
       expire_in: 20 yrs
     release-sdk-artifacts:
+      name: "irma6-${CI_COMMIT_TAG}-${MULTI_CONF}-sdk"
       paths:
-        - "${MULTI_CONF}-sdk.tar.gz"
+        - "artifacts"
+    release-qemu-artifacts:
+      name: "irma6-${CI_COMMIT_TAG}-${MULTI_CONF}-qemu"
+      paths:
+        - "${MULTI_CONF}-deploy.tar.gz"

--- a/.gitlab/test-qemu-template.yml
+++ b/.gitlab/test-qemu-template.yml
@@ -35,6 +35,8 @@
     - ssh -p 2222 -o "StrictHostKeyChecking=no" root@127.0.0.1 "test_von_count --gtest_repeat=3 --gtest_shuffle --gtest_output=xml:/tmp/gtest_results.xml" || true
     - scp -P 2222 -o "StrictHostKeyChecking=no" root@127.0.0.1:/tmp/gtest_results.xml ${MULTI_CONF}-gtest_results.xml
   artifacts:
+    when: always
+    name: "irma6-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-${MULTI_CONF}-gtest-results"
     paths:
       - ${MULTI_CONF}-gtest_results.xml
     reports:


### PR DESCRIPTION
- Artifacts are now named, making it easier to differentiate downloaded
  artifacts.
- Artifacts (except from the qemu build for technical reasons) are now
  not additionally compressed in a tar.gz. Thus, individual files can
  now be viewed and downloaded via gitlab, without having to download
  all the artifacts at once.
- In case of build failure, the gitlab pipeline will now expose all
  package relevant logs as artifacts. This should make debugging build
  failures within the pipeline easier.